### PR TITLE
fix 镂空按钮 中disabled属性无效

### DIFF
--- a/src/components/buttons/button.vue
+++ b/src/components/buttons/button.vue
@@ -5,9 +5,8 @@
   'weui-btn_default': origin,
   'weui-btn_plain-default': plain,
   'weui-btn_plain-primary': plainPrimary,
-  'weui-btn_mini': mini,
-  'weui-btn_disabled': disabled
-  }, 'weui-btn']" :disabled='disabled' @click='onItemClick'>
+  'weui-btn_mini': mini
+  }, 'weui-btn', disabledType]" :disabled='disabled' @click='onItemClick'>
     <slot></slot>
   </a>
 </template>
@@ -44,6 +43,17 @@ export default {
     disabled: {
       type: Boolean,
       default: false
+    }
+  },
+  computed: {
+    disabledType () {
+      if (this.disabled & !this.plain) {
+        return "weui-btn_disabled"
+      } else if (this.disabled & this.plain) {
+        return "weui-btn_plain-disabled"
+      } else {
+        return
+      }
     }
   }
 }


### PR DESCRIPTION
参考[weui](https://github.com/weui/weui/wiki/Button)中button的样式，非镂空按钮disabled的样式是`weui-btn_disabled`，而镂空按钮disabled的样式是`weui-btn_plain-disabled`。 所以您的代码在镂空按钮下disabled属性是无效的，需要计算属性来判断得出disabled的css